### PR TITLE
Update dependencies to match GeoJSON.Net v0.1.47

### DIFF
--- a/src/GeoJSON.Net.Contrib.MsSqlSpatial.Test/GeoJSON.Net.Contrib.MsSqlSpatial.Test.csproj
+++ b/src/GeoJSON.Net.Contrib.MsSqlSpatial.Test/GeoJSON.Net.Contrib.MsSqlSpatial.Test.csproj
@@ -40,16 +40,16 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="GeoJSON.Net, Version=0.1.38.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\GeoJSON.Net.0.1.38\lib\GeoJSON.Net.dll</HintPath>
+    <Reference Include="GeoJSON.Net, Version=0.1.47.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\GeoJSON.Net.0.1.47\lib\portable-net40+sl5+wp80+win8+wpa81\GeoJSON.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.SqlServer.Types, Version=11.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.SqlServer.Types.11.0.2\lib\net20\Microsoft.SqlServer.Types.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -72,8 +72,8 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <Compile Include="SqlServerTypes\Loader.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SqlServerTypes\Loader.cs" />
     <Compile Include="ToGeoJSONGeographyTests.cs" />
     <Compile Include="ToSqlGeographyTests.cs" />
     <Compile Include="ToSqlGeometryTests.cs" />
@@ -84,6 +84,10 @@
       <Project>{129affb0-773b-4f50-bfec-e0856c19eed6}</Project>
       <Name>GeoJSON.Net.Contrib.MsSqlSpatial</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\packages\Microsoft.SqlServer.Types.11.0.2\nativeBinaries\x64\msvcr100.dll">
@@ -103,10 +107,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="SqlServerTypes\readme.htm" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="app.config" />
-    <None Include="packages.config" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/src/GeoJSON.Net.Contrib.MsSqlSpatial.Test/app.config
+++ b/src/GeoJSON.Net.Contrib.MsSqlSpatial.Test/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/GeoJSON.Net.Contrib.MsSqlSpatial.Test/packages.config
+++ b/src/GeoJSON.Net.Contrib.MsSqlSpatial.Test/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GeoJSON.Net" version="0.1.38" targetFramework="net40" />
-  <package id="Microsoft.SqlServer.Types" version="11.0.2" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
+  <package id="GeoJSON.Net" version="0.1.47" targetFramework="net45" />
+  <package id="Microsoft.SqlServer.Types" version="11.0.2" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
 </packages>

--- a/src/GeoJSON.Net.Contrib.MsSqlSpatial.nuspec
+++ b/src/GeoJSON.Net.Contrib.MsSqlSpatial.nuspec
@@ -13,9 +13,8 @@
     <licenseUrl>https://github.com/GeoJSON-Net/GeoJSON.Net.Contrib/blob/master/LICENSE</licenseUrl>
     <projectUrl>https://github.com/GeoJSON-Net/GeoJSON.Net.Contrib/blob/master/README.md</projectUrl>
     <dependencies>
-      <dependency id="GeoJSON.Net" version="0.1.42" />
+      <dependency id="GeoJSON.Net" version="0.1.47" />
       <dependency id="Microsoft.SqlServer.Types" version="11.0.2" />
-      <dependency id="Newtonsoft.Json" version="8.0.2" />
     </dependencies>
     <tags>GeoJSON JSON List SQL Spatial Converters Conversion</tags>
   </metadata>

--- a/src/GeoJSON.Net.Contrib.MsSqlSpatial/GeoJSON.Net.Contrib.MsSqlSpatial.csproj
+++ b/src/GeoJSON.Net.Contrib.MsSqlSpatial/GeoJSON.Net.Contrib.MsSqlSpatial.csproj
@@ -36,16 +36,16 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="GeoJSON.Net, Version=0.1.38.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\GeoJSON.Net.0.1.38\lib\GeoJSON.Net.dll</HintPath>
+    <Reference Include="GeoJSON.Net, Version=0.1.47.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\GeoJSON.Net.0.1.47\lib\portable-net40+sl5+wp80+win8+wpa81\GeoJSON.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.SqlServer.Types, Version=11.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.SqlServer.Types.11.0.2\lib\net20\Microsoft.SqlServer.Types.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -70,6 +70,10 @@
     <Compile Include="SqlServerTypes\Loader.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
     <Content Include="..\packages\Microsoft.SqlServer.Types.11.0.2\nativeBinaries\x64\msvcr100.dll">
       <Link>SqlServerTypes\x64\msvcr100.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -87,10 +91,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="SqlServerTypes\readme.htm" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="app.config" />
-    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/src/GeoJSON.Net.Contrib.MsSqlSpatial/app.config
+++ b/src/GeoJSON.Net.Contrib.MsSqlSpatial/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.0" newVersion="7.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/GeoJSON.Net.Contrib.MsSqlSpatial/packages.config
+++ b/src/GeoJSON.Net.Contrib.MsSqlSpatial/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="GeoJSON.Net" version="0.1.38" targetFramework="net40" />
-  <package id="Microsoft.SqlServer.Types" version="11.0.2" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
+  <package id="GeoJSON.Net" version="0.1.47" targetFramework="net45" />
+  <package id="Microsoft.SqlServer.Types" version="11.0.2" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This is the current latest version of GeoJSON.Net

- Updates from v0.1.42 => v0.1.47
- Downgrades from Newtonsoft v8 => v7 (to match GeoJSON.Net)