### PR TITLE
Make MsSqlSpatial BoundingBox optional

### DIFF
--- a/src/GeoJSON.Net.Contrib.MsSqlSpatial/MsSqlSpatialConvertToGeoJson.cs
+++ b/src/GeoJSON.Net.Contrib.MsSqlSpatial/MsSqlSpatialConvertToGeoJson.cs
@@ -23,12 +23,13 @@ namespace GeoJSON.Net.Contrib.MsSqlSpatial
 	{
 		#region SqlGeometry to GeoJSON
 
-		/// <summary>
-		/// Converts a native Sql Server geometry (lat/lon) to GeoJSON geometry
-		/// </summary>
-		/// <param name="sqlGeometry">SQL Server geometry to convert</param>
-		/// <returns>GeoJSON geometry</returns>
-		public static IGeometryObject ToGeoJSONGeometry(this SqlGeometry sqlGeometry)
+	    /// <summary>
+	    /// Converts a native Sql Server geometry (lat/lon) to GeoJSON geometry
+	    /// </summary>
+	    /// <param name="sqlGeometry">SQL Server geometry to convert</param>
+	    /// <param name="withBoundingBox">Value indicating whether the feature's BoundingBox should be set.</param>
+	    /// <returns>GeoJSON geometry</returns>
+	    public static IGeometryObject ToGeoJSONGeometry(this SqlGeometry sqlGeometry, bool withBoundingBox = true)
 		{
 			if (sqlGeometry == null || sqlGeometry.IsNull)
 			{
@@ -43,17 +44,18 @@ namespace GeoJSON.Net.Contrib.MsSqlSpatial
 			}
 
 			// Conversion using geometry sink
-			SqlGeometryGeoJsonSink sink = new SqlGeometryGeoJsonSink();
+			SqlGeometryGeoJsonSink sink = new SqlGeometryGeoJsonSink(withBoundingBox);
 			sqlGeometry.Populate(sink);
 			return sink.ConstructedGeometry;
 		}
 
-		/// <summary>
-		/// Converts a native Sql Server geometry (lat/lon) to GeoJSON geometry
-		/// </summary>
-		/// <param name="sqlGeometry">SQL Server geometry to convert</param>
-		/// <returns>GeoJSON geometry</returns>
-		public static T ToGeoJSONObject<T>(this  SqlGeometry sqlGeometry) where T : GeoJSONObject
+	    /// <summary>
+	    /// Converts a native Sql Server geometry (lat/lon) to GeoJSON geometry
+	    /// </summary>
+	    /// <param name="sqlGeometry">SQL Server geometry to convert</param>
+	    /// <param name="withBoundingBox">Value indicating whether the feature's BoundingBox should be set.</param>
+	    /// <returns>GeoJSON geometry</returns>
+	    public static T ToGeoJSONObject<T>(this  SqlGeometry sqlGeometry, bool withBoundingBox = true) where T : GeoJSONObject
 		{
 			if (sqlGeometry == null || sqlGeometry.IsNull)
 			{
@@ -72,7 +74,8 @@ namespace GeoJSON.Net.Contrib.MsSqlSpatial
 			SqlGeometryGeoJsonSink sink = new SqlGeometryGeoJsonSink();
 			sqlGeometry.Populate(sink);
 			geoJSONobj = sink.ConstructedGeometry as T;
-			geoJSONobj.BoundingBoxes = sink.BoundingBox;
+
+		    geoJSONobj.BoundingBoxes = withBoundingBox ? sink.BoundingBox : null;
 
 			return geoJSONobj;
 		}
@@ -106,12 +109,13 @@ namespace GeoJSON.Net.Contrib.MsSqlSpatial
 			return sink.ConstructedGeography;
 		}
 
-		/// <summary>
-		/// Converts a native Sql Server geography to GeoJSON geometry
-		/// </summary>
-		/// <param name="sqlGeography">SQL Server geography to convert</param>
-		/// <returns>GeoJSON geometry</returns>
-		public static T ToGeoJSONObject<T>(this SqlGeography sqlGeography) where T : GeoJSONObject
+	    /// <summary>
+	    /// Converts a native Sql Server geography to GeoJSON geometry
+	    /// </summary>
+	    /// <param name="sqlGeography">SQL Server geography to convert</param>
+	    /// <param name="withBoundingBox">Value indicating whether the feature's BoundingBox should be set.</param>
+	    /// <returns>GeoJSON geometry</returns>
+	    public static T ToGeoJSONObject<T>(this SqlGeography sqlGeography, bool withBoundingBox = true) where T : GeoJSONObject
 		{
 			if (sqlGeography == null || sqlGeography.IsNull)
 			{
@@ -130,7 +134,7 @@ namespace GeoJSON.Net.Contrib.MsSqlSpatial
 			SqlGeographyGeoJsonSink sink = new SqlGeographyGeoJsonSink();
 			sqlGeography.Populate(sink);
 			geoJSONobj = sink.ConstructedGeography as T;
-			geoJSONobj.BoundingBoxes = sink.BoundingBox;
+		    geoJSONobj.BoundingBoxes = withBoundingBox ? sink.BoundingBox : null;
 
 			return geoJSONobj;
 		}

--- a/src/GeoJSON.Net.Contrib.MsSqlSpatial/Sinks/SqlGeographyGeoJSONSink.cs
+++ b/src/GeoJSON.Net.Contrib.MsSqlSpatial/Sinks/SqlGeographyGeoJSONSink.cs
@@ -27,6 +27,13 @@ namespace GeoJSON.Net.Contrib.MsSqlSpatial.Sinks
 		double _lonMax = -180;
 		double _latMax = -90;
 
+	    private readonly bool _withBoundingBox;
+
+	    public SqlGeographyGeoJsonSink(bool withBoundingBox = true)
+	    {
+	        this._withBoundingBox = withBoundingBox;
+	    }
+
 		#region Sink implementation
 
 		public void BeginGeography(OpenGisGeographyType type)
@@ -136,7 +143,7 @@ namespace GeoJSON.Net.Contrib.MsSqlSpatial.Sinks
 						List<IGeometryObject> subGeometries = _geomCollection.SubItems.Select(subItem => GeometryFromSinkGeometryCollection(subItem)).ToList();
 						_geometry = new GeometryCollection(subGeometries);
 
-						((GeometryCollection)_geometry).BoundingBoxes = this.BoundingBox;
+						((GeometryCollection)_geometry).BoundingBoxes = this._withBoundingBox ? this.BoundingBox : null;
 						break;
 					default:
 						throw new NotSupportedException("Geometry type " + _geomCollection.GeometryType.ToString() + " is not supported yet.");
@@ -155,33 +162,33 @@ namespace GeoJSON.Net.Contrib.MsSqlSpatial.Sinks
 			{
 				case OpenGisGeographyType.Point:
 					_geometry = ConstructGeometryPart(sinkCollection[0]);
-					((Point)_geometry).BoundingBoxes = this.BoundingBox;
+					((Point)_geometry).BoundingBoxes = this._withBoundingBox ? this.BoundingBox : null;
 					break;
 				case OpenGisGeographyType.MultiPoint:
 					_geometry = new MultiPoint(sinkCollection.Skip(1)
 																										.Select(g => (Point)ConstructGeometryPart(g))
 																										.ToList());
-					((MultiPoint)_geometry).BoundingBoxes = this.BoundingBox;
+					((MultiPoint)_geometry).BoundingBoxes = this._withBoundingBox ? this.BoundingBox : null;
 					break;
 				case OpenGisGeographyType.LineString:
 					_geometry = ConstructGeometryPart(sinkCollection[0]);
-					((LineString)_geometry).BoundingBoxes = this.BoundingBox;
+					((LineString)_geometry).BoundingBoxes = this._withBoundingBox ? this.BoundingBox : null;
 					break;
 				case OpenGisGeographyType.MultiLineString:
 					_geometry = new MultiLineString(sinkCollection.Skip(1)
 																												.Select(g => (LineString)ConstructGeometryPart(g))
 																												.ToList());
-					((MultiLineString)_geometry).BoundingBoxes = this.BoundingBox;
+					((MultiLineString)_geometry).BoundingBoxes = this._withBoundingBox ? this.BoundingBox : null;
 					break;
 				case OpenGisGeographyType.Polygon:
 					_geometry = ConstructGeometryPart(sinkCollection.First());
-					((Polygon)_geometry).BoundingBoxes = this.BoundingBox;
+					((Polygon)_geometry).BoundingBoxes = this._withBoundingBox ? this.BoundingBox : null;
 					break;
 				case OpenGisGeographyType.MultiPolygon:
 					_geometry = new MultiPolygon(sinkCollection.Skip(1)
 																												.Select(g => (Polygon)ConstructGeometryPart(g))
 																												.ToList());
-					((MultiPolygon)_geometry).BoundingBoxes = this.BoundingBox;
+					((MultiPolygon)_geometry).BoundingBoxes = this._withBoundingBox ? this.BoundingBox : null;
 					break;
 				default:
 					throw new NotSupportedException("Geometry type " + sinkCollection.GeometryType.ToString() + " is not possible in GetConstructedGeometry.");
@@ -194,10 +201,7 @@ namespace GeoJSON.Net.Contrib.MsSqlSpatial.Sinks
 
 		public double[] BoundingBox
 		{
-			get
-			{
-				return new double[] { _lonMin, _latMin, _lonMax, _latMax };
-			}
+			get { return this._withBoundingBox ? new double[] {_lonMin, _latMin, _lonMax, _latMax} : null; }
 		}
 
 		private IGeometryObject ConstructGeometryPart(SinkGeometry<OpenGisGeographyType> geomPart)

--- a/src/GeoJSON.Net.Contrib.MsSqlSpatial/Sinks/SqlGeometryGeoJSONSink.cs
+++ b/src/GeoJSON.Net.Contrib.MsSqlSpatial/Sinks/SqlGeometryGeoJSONSink.cs
@@ -28,6 +28,13 @@ namespace GeoJSON.Net.Contrib.MsSqlSpatial.Sinks
 		double _xmax = double.MinValue;
 		double _ymax = double.MinValue;
 
+	    private readonly bool _withBoundingBox;
+
+	    public SqlGeometryGeoJsonSink(bool withBoundingBox = true)
+	    {
+	        this._withBoundingBox = withBoundingBox;
+	    }
+
 		#region Sink implementation
 
 		public void BeginGeometry(OpenGisGeometryType type)
@@ -134,7 +141,7 @@ namespace GeoJSON.Net.Contrib.MsSqlSpatial.Sinks
 						List<IGeometryObject> subGeometries = _geomCollection.SubItems.Select(subItem => GeometryFromSinkGeometryCollection(subItem)).ToList();
 						_geometry = new GeometryCollection(subGeometries);
 
-						((GeometryCollection)_geometry).BoundingBoxes = this.BoundingBox;
+					    ((GeometryCollection)_geometry).BoundingBoxes = this._withBoundingBox ? this.BoundingBox : null;
 						break;
 					default:
 						throw new NotSupportedException("Geometry type " + _geomCollection.GeometryType.ToString() + " is not supported yet.");
@@ -153,33 +160,33 @@ namespace GeoJSON.Net.Contrib.MsSqlSpatial.Sinks
 			{
 				case OpenGisGeometryType.Point:
 					_geometry = ConstructGeometryPart(sinkCollection[0]);
-					((Point)_geometry).BoundingBoxes = this.BoundingBox;
+					((Point)_geometry).BoundingBoxes = this._withBoundingBox ? this.BoundingBox : null;
 					break;
 				case OpenGisGeometryType.MultiPoint:
 					_geometry = new MultiPoint(sinkCollection.Skip(1)
 																										.Select(g => (Point)ConstructGeometryPart(g))
 																										.ToList());
-					((MultiPoint)_geometry).BoundingBoxes = this.BoundingBox;
+					((MultiPoint)_geometry).BoundingBoxes = this._withBoundingBox ? this.BoundingBox : null;
 					break;
 				case OpenGisGeometryType.LineString:
 					_geometry = ConstructGeometryPart(sinkCollection[0]);
-					((LineString)_geometry).BoundingBoxes = this.BoundingBox;
+					((LineString)_geometry).BoundingBoxes = this._withBoundingBox ? this.BoundingBox : null;
 					break;
 				case OpenGisGeometryType.MultiLineString:
 					_geometry = new MultiLineString(sinkCollection.Skip(1)
 																												.Select(g => (LineString)ConstructGeometryPart(g))
 																												.ToList());
-					((MultiLineString)_geometry).BoundingBoxes = this.BoundingBox;
+					((MultiLineString)_geometry).BoundingBoxes = this._withBoundingBox ? this.BoundingBox : null;
 					break;
 				case OpenGisGeometryType.Polygon:
 					_geometry = ConstructGeometryPart(sinkCollection.First());
-					((Polygon)_geometry).BoundingBoxes = this.BoundingBox;
+					((Polygon)_geometry).BoundingBoxes = this._withBoundingBox ? this.BoundingBox : null;
 					break;
 				case OpenGisGeometryType.MultiPolygon:
 					_geometry = new MultiPolygon(sinkCollection.Skip(1)
 																												.Select(g => (Polygon)ConstructGeometryPart(g))
 																												.ToList());
-					((MultiPolygon)_geometry).BoundingBoxes = this.BoundingBox;
+					((MultiPolygon)_geometry).BoundingBoxes = this._withBoundingBox ? this.BoundingBox : null;
 					break;
 				default:
 					throw new NotSupportedException("Geometry type " + sinkCollection.GeometryType.ToString() + " is not possible in GetConstructedGeometry.");
@@ -191,10 +198,7 @@ namespace GeoJSON.Net.Contrib.MsSqlSpatial.Sinks
 
 		public double[] BoundingBox
 		{
-			get
-			{
-				return new double[] { _xmin, _ymin, _xmax, _ymax };
-			}
+			get { return this._withBoundingBox ? new double[] {_xmin, _ymin, _xmax, _ymax} : null; }
 		}
 
 		private IGeometryObject ConstructGeometryPart(SinkGeometry<OpenGisGeometryType> geomPart)

--- a/test/GeoJSON.Net.Contrib.MsSqlSpatial.Test/ToGeoJSONGeographyTests.cs
+++ b/test/GeoJSON.Net.Contrib.MsSqlSpatial.Test/ToGeoJSONGeographyTests.cs
@@ -228,6 +228,106 @@ namespace GeoJSON.Net.MsSqlSpatial.Tests
 
         }
 
+        [TestMethod]
+        [TestCategory("ToGeoJSONGeography")]
+        public void TestGeometryCollectionWithoutBoundingBox()
+        {
+            var geoJSONobj = this.geomCol.ToGeoJSONObject<GeometryCollection>(false);
+
+            Assert.IsNotNull(geoJSONobj);
+            Assert.AreEqual(geoJSONobj.Type, GeoJSONObjectType.GeometryCollection);
+            Assert.IsNull(geoJSONobj.BoundingBoxes);
+            Assert.AreEqual(geoJSONobj.Geometries.Count, 3);
+            Assert.AreEqual(geoJSONobj.Geometries[0].Type, GeoJSONObjectType.Polygon);
+            Assert.AreEqual(geoJSONobj.Geometries[1].Type, GeoJSONObjectType.Point);
+            Assert.AreEqual(geoJSONobj.Geometries[2].Type, GeoJSONObjectType.MultiLineString);
+        }
+
+        [TestMethod]
+        [TestCategory("ToGeoJSONGeography")]
+        public void TestLineStringWithoutBoundingBox()
+        {
+            var geoJSONobj = this.lineString.ToGeoJSONObject<LineString>(false);
+
+            Assert.IsNotNull(geoJSONobj);
+            Assert.AreEqual(geoJSONobj.Type, GeoJSONObjectType.LineString);
+            Assert.IsNull(geoJSONobj.BoundingBoxes);
+        }
+
+        [TestMethod]
+        [TestCategory("ToGeoJSONGeography")]
+        public void TestMultiLineStringWithoutBoundingBox()
+        {
+            var geoJSONobj = this.multiLineString.ToGeoJSONObject<MultiLineString>(false);
+
+            Assert.IsNotNull(geoJSONobj);
+            Assert.AreEqual(geoJSONobj.Type, GeoJSONObjectType.MultiLineString);
+            Assert.IsNull(geoJSONobj.BoundingBoxes);
+        }
+
+        [TestMethod]
+        [TestCategory("ToGeoJSONGeography")]
+        public void TestSimplePointWithoutBoundingBox()
+        {
+            Point geoJSONobj = this.simplePoint.ToGeoJSONObject<Point>(false);
+
+            Assert.IsNotNull(geoJSONobj);
+            Assert.AreEqual(geoJSONobj.Type, GeoJSONObjectType.Point);
+            Assert.IsNull(geoJSONobj.BoundingBoxes);
+        }
+
+        [TestMethod]
+        [TestCategory("ToGeoJSONGeography")]
+        public void TestMultiPointWithoutBoundingBox()
+        {
+            MultiPoint geoJSONobj = this.multiPoint.ToGeoJSONObject<MultiPoint>(false);
+
+            Assert.IsNotNull(geoJSONobj);
+            Assert.AreEqual(geoJSONobj.Type, GeoJSONObjectType.MultiPoint);
+            Assert.IsNull(geoJSONobj.BoundingBoxes);
+        }
+
+        [TestMethod]
+        [TestCategory("ToGeoJSONGeography")]
+        public void TestSimplePolygonWithoutBoundingBox()
+        {
+            var geoJSONobj = this.simplePoly.ToGeoJSONObject<Polygon>(false);
+
+            Assert.IsNotNull(geoJSONobj);
+            Assert.AreEqual(geoJSONobj.Type, GeoJSONObjectType.Polygon);
+            Assert.IsNull(geoJSONobj.BoundingBoxes);
+            Assert.AreEqual(geoJSONobj.Coordinates.Count, 1);
+        }
+
+        [TestMethod]
+        [TestCategory("ToGeoJSONGeography")]
+        public void TestPolygonWitHoleWithoutBoundingBox()
+        {
+            var geoJSONobj = this.polyWithHole.ToGeoJSONObject<Polygon>(false);
+
+            Assert.IsNotNull(geoJSONobj);
+            Assert.AreEqual(geoJSONobj.Type, GeoJSONObjectType.Polygon);
+            Assert.IsNull(geoJSONobj.BoundingBoxes);
+            Assert.AreEqual(geoJSONobj.Coordinates.Count, 2);
+        }
+
+        [TestMethod]
+        [TestCategory("ToGeoJSONGeography")]
+        public void TestMultiPolygonWithoutBoundingBox()
+        {
+            var geoJSONobj = this.multiPolygon.ToGeoJSONObject<MultiPolygon>(false);
+
+            Assert.IsNotNull(geoJSONobj);
+            Assert.AreEqual(geoJSONobj.Type, GeoJSONObjectType.MultiPolygon);
+            Assert.IsNull(geoJSONobj.BoundingBoxes);
+            Assert.AreEqual(geoJSONobj.Coordinates.Count, 3);
+            Assert.AreEqual(geoJSONobj.Coordinates[1].Coordinates.Count, 2);
+            Assert.AreEqual(geoJSONobj.Coordinates[1].Coordinates[0].Coordinates.Count, 6);
+            Assert.AreEqual(geoJSONobj.Coordinates[1].Coordinates[1].Coordinates.Count, 4);
+            Assert.AreEqual(geoJSONobj.Coordinates[2].Coordinates[0].Coordinates.Count, 5);
+            Assert.AreEqual(geoJSONobj.Coordinates[2].Coordinates[1].Coordinates.Count, 5);
+        }
+
         #region Test geographies
 
         SqlGeography simplePoint = SqlGeography.Parse(new SqlString(WktSamples.POINT)).MakeValidIfInvalid();


### PR DESCRIPTION
RFC 7946 The GeoJSON Format states (https://tools.ietf.org/html/rfc7946):

> A GeoJSON object MAY have a member named "bbox" to include information on the coordinate range for its Geometries, Features, or FeatureCollections

There should be a way to make this property optional - this update provides an optional parameter to the method that does the conversion from SqlGeometry to GeoJSON so that this property can be made optional.

The default value is set to `true` so that it does not interfere with existing code that uses the library but provides an extension point for new development that may not want this property set.

Unit tests were added to verify that the behavior does not change when the interface is used instead of the concrete implementation.

Resolves: #18