### PR TITLE
Add support for 3D geometries to the WKB library

### DIFF
--- a/test/GeoJSON.Net.Contrib.Wkb.Test/EncodeDecodeTests.cs
+++ b/test/GeoJSON.Net.Contrib.Wkb.Test/EncodeDecodeTests.cs
@@ -13,15 +13,15 @@ namespace GeoJSON.Net.Contrib.Wkb.Test
             Assert.Equal(point, processedPoint);
         }
 
-        [Fact(Skip = "Equal method does not seem to be working right")]
+        [Fact]
         public void EncodeDecodeMultiPointTest()
         {
             var processedMultiPoint = multiPoint.ToWkb().ToGeoJSONObject<MultiPoint>();
 
-            Assert.Equal(multiPoint, processedMultiPoint);            
+            Assert.Equal(multiPoint, processedMultiPoint);
         }
 
-        [Fact(Skip = "Equal method does not seem to be working right")]
+        [Fact]
         public void EncodeDecodeLineStringTest()
         {
             var processedLineString = lineString.ToWkb().ToGeoJSONObject<LineString>();
@@ -29,7 +29,7 @@ namespace GeoJSON.Net.Contrib.Wkb.Test
             Assert.Equal(lineString, processedLineString);
         }
 
-        [Fact(Skip = "Equal method does not seem to be working right")]
+        [Fact]
         public void EncodeDecodeMultiLineStringTest()
         {
             var processedMultiLineString = multiLineString.ToWkb().ToGeoJSONObject<MultiLineString>();
@@ -37,7 +37,7 @@ namespace GeoJSON.Net.Contrib.Wkb.Test
             Assert.Equal(multiLineString, processedMultiLineString);      
         }
 
-        [Fact(Skip = "Equal method does not seem to be working right")]
+        [Fact]
         public void EncodeDecodePolygonTest()
         {
             var processedPolygon = polygon.ToWkb().ToGeoJSONObject<Polygon>();
@@ -69,7 +69,7 @@ namespace GeoJSON.Net.Contrib.Wkb.Test
             Assert.Equal(multiPolygon, processedMultiPolygon);
         }
 
-        [Fact(Skip = "Equal method does not seem to be working right")]
+        [Fact]
         public void EncodeDecodeGeometryCollectionTest()
         {
             var processedGeomCol = geomCollection.ToWkb().ToGeoJSONObject<GeometryCollection>();

--- a/test/GeoJSON.Net.Contrib.Wkb.Test/EncodeDecodeTests.cs
+++ b/test/GeoJSON.Net.Contrib.Wkb.Test/EncodeDecodeTests.cs
@@ -45,20 +45,20 @@ namespace GeoJSON.Net.Contrib.Wkb.Test
             Assert.Equal(polygon, processedPolygon);
         }
 
-        [Fact(Skip = "Equal method does not seem to be working right")]
+        [Fact]
         public void EncodeDecodePolygonWithHoleTest()
         {
             var processedPolygon = polygonWithHole.ToWkb().ToGeoJSONObject<Polygon>();
 
-            Assert.Equal(polygon, processedPolygon);
+            Assert.Equal(polygonWithHole, processedPolygon);
         }
 
-        [Fact(Skip = "Equal method does not seem to be working right")]
+        [Fact]
         public void EncodeDecodePolygonWithHoleReverseWindingTest()
         {
             var processedPolygon = polygonWithHoleReverseWinding.ToWkb().ToGeoJSONObject<Polygon>();
 
-            Assert.Equal(polygon, processedPolygon);
+            Assert.Equal(polygonWithHoleReverseWinding, processedPolygon);
         }
 
         [Fact]

--- a/test/GeoJSON.Net.Contrib.Wkb.Test/EncodeDecodeTests.cs
+++ b/test/GeoJSON.Net.Contrib.Wkb.Test/EncodeDecodeTests.cs
@@ -14,11 +14,27 @@ namespace GeoJSON.Net.Contrib.Wkb.Test
         }
 
         [Fact]
+        public void EncodeDecodePointZTest()
+        {
+            var processedPointZ = pointZ.ToWkb().ToGeoJSONObject<Point>();
+
+            Assert.Equal(pointZ, processedPointZ);
+        }
+
+        [Fact]
         public void EncodeDecodeMultiPointTest()
         {
             var processedMultiPoint = multiPoint.ToWkb().ToGeoJSONObject<MultiPoint>();
 
             Assert.Equal(multiPoint, processedMultiPoint);
+        }
+
+        [Fact]
+        public void EncodeDecodeMultiPointZTest()
+        {
+            var processedMultiPointZ = multiPointZ.ToWkb().ToGeoJSONObject<MultiPoint>();
+
+            Assert.Equal(multiPointZ, processedMultiPointZ);
         }
 
         [Fact]
@@ -30,11 +46,27 @@ namespace GeoJSON.Net.Contrib.Wkb.Test
         }
 
         [Fact]
+        public void EncodeDecodeLineStringZTest()
+        {
+            var processedLineStringZ = lineStringZ.ToWkb().ToGeoJSONObject<LineString>();
+
+            Assert.Equal(lineStringZ, processedLineStringZ);
+        }
+
+        [Fact]
         public void EncodeDecodeMultiLineStringTest()
         {
             var processedMultiLineString = multiLineString.ToWkb().ToGeoJSONObject<MultiLineString>();
 
-            Assert.Equal(multiLineString, processedMultiLineString);      
+            Assert.Equal(multiLineString, processedMultiLineString);
+        }
+
+        [Fact]
+        public void EncodeDecodeMultiLineStringZTest()
+        {
+            var processedMultiLineStringZ = multiLineStringZ.ToWkb().ToGeoJSONObject<MultiLineString>();
+
+            Assert.Equal(multiLineStringZ, processedMultiLineStringZ);
         }
 
         [Fact]
@@ -43,6 +75,14 @@ namespace GeoJSON.Net.Contrib.Wkb.Test
             var processedPolygon = polygon.ToWkb().ToGeoJSONObject<Polygon>();
 
             Assert.Equal(polygon, processedPolygon);
+        }
+
+        [Fact]
+        public void EncodeDecodePolygonZTest()
+        {
+            var processedPolygonZ = polygonZ.ToWkb().ToGeoJSONObject<Polygon>();
+
+            Assert.Equal(polygonZ, processedPolygonZ);
         }
 
         [Fact]
@@ -70,11 +110,27 @@ namespace GeoJSON.Net.Contrib.Wkb.Test
         }
 
         [Fact]
+        public void EncodeDecodeMultiPolygonZTest()
+        {
+            var processedMultiPolygonZ = multiPolygonZ.ToWkb().ToGeoJSONObject<MultiPolygon>();
+
+            Assert.Equal(multiPolygonZ, processedMultiPolygonZ);
+        }
+
+        [Fact]
         public void EncodeDecodeGeometryCollectionTest()
         {
             var processedGeomCol = geomCollection.ToWkb().ToGeoJSONObject<GeometryCollection>();
 
             Assert.Equal(geomCollection, processedGeomCol);
+        }
+
+        [Fact]
+        public void EncodeDecodeGeometryCollectionZTest()
+        {
+            var processedGeomColZ = geomCollectionZ.ToWkb().ToGeoJSONObject<GeometryCollection>();
+
+            Assert.Equal(geomCollectionZ, processedGeomColZ);
         }
     }
 }

--- a/test/GeoJSON.Net.Contrib.Wkb.Test/WkbConversionsTests.cs
+++ b/test/GeoJSON.Net.Contrib.Wkb.Test/WkbConversionsTests.cs
@@ -8,14 +8,21 @@ namespace GeoJSON.Net.Contrib.Wkb.Test
     public partial class WkbConversionsTests
     {
         Point point;
+        Point pointZ;
         MultiPoint multiPoint;
+        MultiPoint multiPointZ;
         LineString lineString;
+        LineString lineStringZ;
         MultiLineString multiLineString;
+        MultiLineString multiLineStringZ;
         Polygon polygon;
+        Polygon polygonZ;
         Polygon polygonWithHole;
         Polygon polygonWithHoleReverseWinding;
         MultiPolygon multiPolygon;
+        MultiPolygon multiPolygonZ;
         GeometryCollection geomCollection;
+        GeometryCollection geomCollectionZ;
         Feature.Feature feature;
         FeatureCollection featureCollection;
 
@@ -23,18 +30,34 @@ namespace GeoJSON.Net.Contrib.Wkb.Test
         {
             point = new Point(new Position(53.2455662, 90.65464646));
 
+            pointZ = new Point(new Position(1, 2, 3));
+
             multiPoint = new MultiPoint(new List<Point>
                 {
                     new Point(new Position(52.379790828551016, 5.3173828125)),
                     new Point(new Position(52.36721467920585, 5.456085205078125)),
                     new Point(new Position(52.303440474272755, 5.386047363281249))
                 });
+
+            multiPointZ = new MultiPoint(new List<Point>
+                {
+                    new Point(new Position(1, 2, 3)),
+                    new Point(new Position(4, 5, 6)),
+                });
+
             lineString = new LineString(new List<IPosition>
                 {
                     new Position(52.379790828551016, 5.3173828125),
                     new Position(52.36721467920585, 5.456085205078125),
                     new Position(52.303440474272755, 5.386047363281249)
                 });
+
+            lineStringZ = new LineString(new List<IPosition>
+                {
+                    new Position(1, 2, 3),
+                    new Position(4, 5, 6)
+                });
+
             multiLineString = new MultiLineString(new List<LineString>
                 {
                     new LineString(new List<IPosition>
@@ -48,6 +71,20 @@ namespace GeoJSON.Net.Contrib.Wkb.Test
                         new Position(52.379790828551016, 5.3273828125),
                         new Position(52.36721467920585, 5.486085205078125),
                         new Position(52.303440474272755, 5.426047363281249)
+                    })
+                });
+
+            multiLineStringZ = new MultiLineString(new List<LineString>
+                {
+                    new LineString(new List<IPosition>
+                    {
+                        new Position(1, 2, 3),
+                        new Position(4, 5, 6)
+                    }),
+                    new LineString(new List<IPosition>
+                    {
+                        new Position(7, 8, 9),
+                        new Position(10, 11, 12)
                     })
                 });
 
@@ -132,6 +169,17 @@ namespace GeoJSON.Net.Contrib.Wkb.Test
                     })
                 });
 
+            polygonZ = new Polygon(new List<LineString>
+                {
+                    new LineString(new List<IPosition>
+                        {
+                            new Position(1, 2, 3),
+                            new Position(4, 5, 3),
+                            new Position(4, 5, 6),
+                            new Position(1, 2, 3),
+                        })
+                });
+
             multiPolygon = new MultiPolygon(new List<Polygon>
                 {
                     new Polygon(new List<LineString>
@@ -169,6 +217,30 @@ namespace GeoJSON.Net.Contrib.Wkb.Test
                     })
                 });
 
+            multiPolygonZ = new MultiPolygon(new List<Polygon>
+                {
+                    new Polygon(new List<LineString>
+                    {
+                        new LineString(new List<IPosition>
+                            {
+                                new Position(1, 2, 3),
+                                new Position(4, 5, 3),
+                                new Position(4, 5, 6),
+                                new Position(1, 2, 3),
+                            })
+                    }),
+                    new Polygon(new List<LineString>
+                    {
+                        new LineString(new List<IPosition>
+                            {
+                                new Position(10, 20, 30),
+                                new Position(40, 50, 30),
+                                new Position(40, 50, 60),
+                                new Position(10, 20, 30),
+                            })
+                    })
+                });
+
             geomCollection = new GeometryCollection(new List<IGeometryObject>
                 {
                     point,
@@ -177,6 +249,16 @@ namespace GeoJSON.Net.Contrib.Wkb.Test
                     multiLineString,
                     polygon,
                     multiPolygon
+                });
+
+            geomCollectionZ = new GeometryCollection(new List<IGeometryObject>
+                {
+                    pointZ,
+                    multiPointZ,
+                    lineStringZ,
+                    multiLineStringZ,
+                    polygonZ,
+                    multiPolygonZ
                 });
 
             feature = new Feature.Feature(polygon, new Dictionary<string, object>() { { "Key", "Value" } }, "Id");

--- a/test/GeoJSON.Net.Contrib.Wkb.Test/WkbConversionsTests.cs
+++ b/test/GeoJSON.Net.Contrib.Wkb.Test/WkbConversionsTests.cs
@@ -27,13 +27,13 @@ namespace GeoJSON.Net.Contrib.Wkb.Test
                 {
                     new Point(new Position(52.379790828551016, 5.3173828125)),
                     new Point(new Position(52.36721467920585, 5.456085205078125)),
-                    new Point(new Position(52.303440474272755, 5.386047363281249, 4.23))
+                    new Point(new Position(52.303440474272755, 5.386047363281249))
                 });
             lineString = new LineString(new List<IPosition>
                 {
                     new Position(52.379790828551016, 5.3173828125),
                     new Position(52.36721467920585, 5.456085205078125),
-                    new Position(52.303440474272755, 5.386047363281249, 4.23)
+                    new Position(52.303440474272755, 5.386047363281249)
                 });
             multiLineString = new MultiLineString(new List<LineString>
                 {
@@ -41,15 +41,16 @@ namespace GeoJSON.Net.Contrib.Wkb.Test
                     {
                         new Position(52.379790828551016, 5.3173828125),
                         new Position(52.36721467920585, 5.456085205078125),
-                        new Position(52.303440474272755, 5.386047363281249, 4.23)
+                        new Position(52.303440474272755, 5.386047363281249)
                     }),
                     new LineString(new List<IPosition>
                     {
                         new Position(52.379790828551016, 5.3273828125),
                         new Position(52.36721467920585, 5.486085205078125),
-                        new Position(52.303440474272755, 5.426047363281249, 4.23)
+                        new Position(52.303440474272755, 5.426047363281249)
                     })
                 });
+
             /*
 			 * POLYGON (
 			 *	new Position(5.6718750056992775 43.179268827576763), 
@@ -125,7 +126,7 @@ namespace GeoJSON.Net.Contrib.Wkb.Test
                     new LineString(new List<Position>
                     {
                         new Position(52.379790828551016, 5.3173828125),
-                        new Position(52.303440474272755, 5.386047363281249, 4.23),
+                        new Position(52.303440474272755, 5.386047363281249),
                         new Position(52.36721467920585, 5.456085205078125),
                         new Position(52.379790828551016, 5.3173828125)
                     })


### PR DESCRIPTION
This PR adds support for 3D geometries to the WKB library. (fixes #27)

The new code is not always written in an optimal way, but I have tried to keep refactoring to the bare minimum and the existing code has some issues already.
I have also fixed the existing unit tests, there were a couple small issues and I needed them working to ensure I didn't break anything.
I've done further testing in code that uses this library to ensure that the GeoJSON is generated as expected.

There is a risk of a breaking change here: when mixing 2D and 3D geometries in `Multi...` types or in `GeometryCollection`, and when the first geometry is 3D, you may see `NaN` instead of `null` for the Z value in both the .NET objects and the GeoJSON. Worst case, there may even be a runtime exception. **However**, the [OGC specification](https://www.ogc.org/standards/sfa) does not allow mixing 2D and 3D geometries, so impact should be somewhere between very low and non-existent.