### PR TITLE
Re-enable strong-signing using "GeoJSON.Net" key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ bld/
 *.ide/
 
 .vs/
+.idea/
 
 # MSTest test Results
 [Tt]est[Rr]esult*/
@@ -130,7 +131,7 @@ publish/
 # Publish Web Output
 *.[Pp]ublish.xml
 *.azurePubxml
-# TODO: Comment the next line if you want to checkin your web deploy settings 
+# TODO: Comment the next line if you want to checkin your web deploy settings
 # but database connection strings (with potential passwords) will be unencrypted
 *.pubxml
 *.publishproj

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,20 @@
+<!--
+
+This file is automatically included in all projects under "src" directory.
+
+Reference for customizing build with "Directory.Build.props":
+https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build
+
+Reference for shared build properties:
+https://docs.microsoft.com/en-us/dotnet/core/tools/csproj#assemblyinfo-properties
+
+-->
+<Project>
+  <PropertyGroup>
+    <!--
+
+    Shared build properties -->
+    <SignAssembly>True</SignAssembly>
+    <AssemblyOriginatorKeyFile>../../src/key.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+</Project>

--- a/src/GeoJSON.Net.Contrib.EntityFramework/GeoJSON.Net.Contrib.EntityFramework.csproj
+++ b/src/GeoJSON.Net.Contrib.EntityFramework/GeoJSON.Net.Contrib.EntityFramework.csproj
@@ -18,9 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="EntityFramework" version="6.1.3" />
-    <PackageReference Include="GeoJSON.Net" version="1.2.15" />
-    <PackageReference Include="GeoJSON.Net.Contrib.Wkb" Version="0.1.5" />
-    <PackageReference Include="Newtonsoft.Json" version="10.0.2" />
+    <ProjectReference Include="../GeoJSON.Net.Contrib.Wkb/GeoJSON.Net.Contrib.Wkb.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GeoJSON.Net.Contrib.Wkb/GeoJSON.Net.Contrib.Wkb.csproj
+++ b/src/GeoJSON.Net.Contrib.Wkb/GeoJSON.Net.Contrib.Wkb.csproj
@@ -18,7 +18,6 @@
 
   <ItemGroup>
     <PackageReference Include="GeoJSON.Net" version="1.2.15" />
-    <PackageReference Include="Newtonsoft.Json" version="10.0.2" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,0 +1,4 @@
+<!-- This file is automatically included in all projects under "test" directory. -->
+<Project>
+  <Import Project="../src/Directory.Build.props" />
+</Project>


### PR DESCRIPTION
This pull request re-enables strong signing of `GeoJSON.Net.Contrib` assemblies that was introduced in #22 by @jgoz and then lost by commit bc8c2b15 (unassociated with a PR).