### PR TITLE
Fix target framework for xunit test runners

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -24,6 +24,7 @@ https://docs.microsoft.com/en-us/dotnet/core/tools/csproj#assemblyinfo-propertie
     <IsTestProject>False</IsTestProject>
     <IsTestProject Condition=" $(MSBuildProjectName.EndsWith('.Test')) ">True</IsTestProject>
     <DefaultTargetFramework>net45</DefaultTargetFramework>
+    <DefaultTargetFrameworkForTests>net452</DefaultTargetFrameworkForTests><!-- xunit test runner 2.4.2 requires at least .NET 4.5.2 -->
     <!--
 
     NuGet package properties

--- a/test/GeoJSON.Net.Contrib.EntityFramework.Test/GeoJSON.Net.Contrib.EntityFramework.Test.csproj
+++ b/test/GeoJSON.Net.Contrib.EntityFramework.Test/GeoJSON.Net.Contrib.EntityFramework.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <TargetFramework>$(DefaultTargetFrameworkForTests)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/GeoJSON.Net.Contrib.MsSqlSpatial.Test/GeoJSON.Net.Contrib.MsSqlSpatial.Test.csproj
+++ b/test/GeoJSON.Net.Contrib.MsSqlSpatial.Test/GeoJSON.Net.Contrib.MsSqlSpatial.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <TargetFramework>$(DefaultTargetFrameworkForTests)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/GeoJSON.Net.Contrib.Wkb.Test/GeoJSON.Net.Contrib.Wkb.Test.csproj
+++ b/test/GeoJSON.Net.Contrib.Wkb.Test/GeoJSON.Net.Contrib.Wkb.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+    <TargetFramework>$(DefaultTargetFrameworkForTests)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes target framework in test projects to allow xunit test runner to discover and execute all tests.

Instroduced by #32 , see [comment thread](https://github.com/GeoJSON-Net/GeoJSON.Net.Contrib/pull/32#issuecomment-653557816) for more information.